### PR TITLE
Improvements to zvmlet

### DIFF
--- a/zvmlet/Dockerfile
+++ b/zvmlet/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add git python3 make g++
 
 # Installing restroom
 RUN yarn create restroom --all restroom-mw
-WORKDIR /restroom-mw
+WORKDIR /app
 
 # Configure restroom
 ENV HTTP_PORT=3000

--- a/zvmlet/docker-compose.yml
+++ b/zvmlet/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       args:
         NODE_VERSION: "16"
     volumes:
-      - ./contracts:/restroom-mw/contracts
+      - ./contracts:/app/contracts

--- a/zvmlet/docker-compose.yml
+++ b/zvmlet/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       args:
         NODE_VERSION: "16"
     volumes:
-      - ./contracts:/app/contracts
+      - ./contracts:/app/contracts:ro


### PR DESCRIPTION
Use `/app` as the WORKDIR of the Dockerfile, since it is more common and shorter to type.
Mount the contracts directory as read-only in docker-compose.yml because it's not supposed to modify them.